### PR TITLE
Allow choosing a queue when marking a message

### DIFF
--- a/lib/Mail/Dir/Message.pm
+++ b/lib/Mail/Dir/Message.pm
@@ -194,6 +194,7 @@ sub mark {
         die("Unable to rename() $self->{'file'} to $new_file: $!");
     }
 
+    $self->{'dir'}   = 'cur';
     $self->{'file'}  = $new_file;
     $self->{'flags'} = $flags;
 


### PR DESCRIPTION
This implements my proposal from #2.

The first commit from this PR fixes an omission in Mail::Dir::Message, where `->mark` moves the message to the `cur` queue but doesn’t update the object’s `dir` field. If you reject the overall PR this patch should still be cherry-picked.